### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR adds the missing standard SciML centralized caller workflows to this repo. These are thin caller files that reference the shared reusable workflows in `SciML/.github`.

Added workflows:
- `DependabotAutoMerge.yml` (dependabot-automerge.yml@v1)

(No `.jl` package source and no Documenter `docs/` directory present, so the auto-format and docs-preview-cleanup workflows were not applicable.)

These were missing relative to the standard SciML set; existing workflows were not modified.

---

**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)